### PR TITLE
Update cachetools to 5.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 botocore
-cachetools
+cachetools==5.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 botocore
-cachetools==4.2.1
+cachetools

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ with open('requirements.txt') as f:
 setuptools.setup(
     name="botocache",
     author="rams3sh",
-    version="0.0.4",
+    version="0.0.5",
     description="Caching for Boto and Boto3 SDK",
     packages=["botocache"],
     install_requires=required,
-    python_requires='>=3.5',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Update cachetools to 5.3.3 which requires python 3.7+.

Tested this:

```
from boto3.session import Session
from cachetools_ext.fs import FSLRUCache

from botocache.botocache import botocache_context

cache = FSLRUCache(ttl=900, path=".cache", maxsize=1000)

# action_regex_to_cache parameter consists list of regex to be matched against a given action for considering the call to be cached
with botocache_context(cache=cache,
                       action_regex_to_cache=["List.*", "Get.*", "Describe.*"],  
                       call_log=True, # This helps in logging all calls made to AWS. Useful while debugging. Default value is False.
                       supress_warning_message=False # This supresses warning messages encountered while caching. Default value is False. 
                       ):
  cached_session = Session()
  cached_client = cached_session.client('ecr')
  paginator = cached_client.get_paginator('describe_repositories')
  for page in paginator.paginate():
    print(page)
```
and output is expected : list of all repositories on ECR.